### PR TITLE
Setup renovate and publish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+name: Publish
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    name: Publish to Eik
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: 16.x
+      - name: Install Dependencies
+        run: |
+          npm install
+      - name: Run Build
+        run: |
+          npm run build
+      - name: Run Publish
+        run: |
+          npm run eik:publish:ci
+        env:
+          EIK_TOKEN: ${{ secrets.EIK_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -173,14 +173,12 @@
     "node_modules/@esm-bundle/react": {
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/@esm-bundle/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-iyGj5cmJG10oeBJ5YEPfjPmcI/sLzFpVZ00JURuBz643JeX/MJgvoEHIMx5BaXnumO7bEMBkM/MlX9dBr4Oj3w==",
-      "dev": true
+      "integrity": "sha512-iyGj5cmJG10oeBJ5YEPfjPmcI/sLzFpVZ00JURuBz643JeX/MJgvoEHIMx5BaXnumO7bEMBkM/MlX9dBr4Oj3w=="
     },
     "node_modules/@esm-bundle/react-dom": {
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/@esm-bundle/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-g0H+LLWYz/YtV5yifA65pQTDO9u/qliir0fqZTClfA5N8OiaonugqiVd8IjQchyKz2F57zh9Xeu9nji4s07MDQ==",
-      "dev": true
+      "integrity": "sha512-g0H+LLWYz/YtV5yifA65pQTDO9u/qliir0fqZTClfA5N8OiaonugqiVd8IjQchyKz2F57zh9Xeu9nji4s07MDQ=="
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -2515,22 +2513,26 @@
     },
     "packages/react": {
       "name": "test-react",
-      "version": "16.14.0",
+      "version": "0.0.0",
       "license": "ISC",
-      "devDependencies": {
-        "@eik/cli": "^2.0.13",
+      "dependencies": {
         "@esm-bundle/react": "16.14.0"
+      },
+      "devDependencies": {
+        "@eik/cli": "^2.0.13"
       }
     },
     "packages/react-dom": {
       "name": "test-react-dom",
-      "version": "16.14.0",
+      "version": "0.0.0",
       "hasInstallScript": true,
       "license": "ISC",
+      "dependencies": {
+        "@esm-bundle/react-dom": "16.14.0"
+      },
       "devDependencies": {
         "@eik/cli": "^2.0.13",
         "@eik/rollup-plugin": "^4.0.9",
-        "@esm-bundle/react-dom": "16.14.0",
         "rollup": "^2.59.0"
       }
     }
@@ -2674,14 +2676,12 @@
     "@esm-bundle/react": {
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/@esm-bundle/react/-/react-16.14.0.tgz",
-      "integrity": "sha512-iyGj5cmJG10oeBJ5YEPfjPmcI/sLzFpVZ00JURuBz643JeX/MJgvoEHIMx5BaXnumO7bEMBkM/MlX9dBr4Oj3w==",
-      "dev": true
+      "integrity": "sha512-iyGj5cmJG10oeBJ5YEPfjPmcI/sLzFpVZ00JURuBz643JeX/MJgvoEHIMx5BaXnumO7bEMBkM/MlX9dBr4Oj3w=="
     },
     "@esm-bundle/react-dom": {
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/@esm-bundle/react-dom/-/react-dom-16.14.0.tgz",
-      "integrity": "sha512-g0H+LLWYz/YtV5yifA65pQTDO9u/qliir0fqZTClfA5N8OiaonugqiVd8IjQchyKz2F57zh9Xeu9nji4s07MDQ==",
-      "dev": true
+      "integrity": "sha512-g0H+LLWYz/YtV5yifA65pQTDO9u/qliir0fqZTClfA5N8OiaonugqiVd8IjQchyKz2F57zh9Xeu9nji4s07MDQ=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -5,10 +5,7 @@
   "main": "index.js",
   "type": "module",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
-    "build": "npm run build -ws --if-present",
-    "eik:login": "eik login",
-    "eik:publish": "npm run eik:publish -ws"
+    "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
   "author": "",

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "npm run build -ws --if-present",

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -1,7 +1,7 @@
 {
   "name": "test-react-dom",
   "private": "true",
-  "version": "16.14.0",
+  "version": "0.0.0",
   "description": "An ESM version of React Dom for Finn",
   "type": "module",
   "scripts": {
@@ -9,15 +9,18 @@
     "eik:login": "eik login",
     "eik:publish": "eik publish",
     "eik:alias": "eik npm-alias",
-    "postinstall": "npm run build"
+    "postinstall": "npm run build",
+    "eik:publish:ci": "../../scripts/publish.js react-dom @esm-bundle/react-dom"
   },
   "keywords": [],
   "author": "",
   "license": "ISC",
+  "dependencies": {
+    "@esm-bundle/react-dom": "16.14.0"
+  },
   "devDependencies": {
     "@eik/cli": "^2.0.13",
     "@eik/rollup-plugin": "^4.0.9",
-    "@esm-bundle/react-dom": "16.14.0",
     "rollup": "^2.59.0"
   },
   "eik": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "test-react",
   "private": "true",
-  "version": "16.14.0",
+  "version": "0.0.0",
   "description": "An ESM version of React for Finn",
   "type": "module",
   "main": "react.production.min.js",
@@ -9,13 +9,16 @@
     "build": "echo \"No build command installed\"",
     "eik:login": "eik login",
     "eik:publish": "eik publish",
-    "eik:alias": "eik npm-alias"
+    "eik:alias": "eik npm-alias",
+    "eik:publish:ci": "../../scripts/publish.js react @esm-bundle/react"
   },
   "author": "",
   "license": "ISC",
-  "devDependencies": {
-    "@eik/cli": "^2.0.13",
+  "dependencies": {
     "@esm-bundle/react": "16.14.0"
+  },
+  "devDependencies": {
+    "@eik/cli": "^2.0.13"
   },
   "eik": {
     "server": "https://assets.finn.no",

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,22 @@
 {
-  "extends": [
-    "config:base"
-  ]
-}
+    "extends": [
+      "config:base"
+    ],
+    "packageRules": [
+        {
+          "depTypeList": ["dependencies"],
+          "automerge": true,
+          "major": {
+            "automerge": false
+          }
+        },
+        {
+          "depTypeList": ["devDependencies"],
+          "schedule": ["before 4am on monday"],
+          "automerge": true,
+          "major": {
+            "automerge": false
+          }
+        }
+      ]
+  }

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -1,0 +1,40 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import eik from '@eik/cli';
+
+// usage: EIK_TOKEN=<eik token> ./publish.js <name of package folder> <name of dependency>
+// example: EIK_TOKEN=<eik token> ./publish.js react @esm-bundle/react
+
+const { EIK_TOKEN } = process.env;
+const dirname = new URL('./', import.meta.url).pathname;
+const [, , packageNameArg, dependencyNameArg] = process.argv;
+const cwd = join(dirname, '../packages', packageNameArg);
+
+// read package.json file
+const packageJSONPath = join(cwd, './package.json');
+const packageJSON = JSON.parse(readFileSync(packageJSONPath, 'utf8'));
+
+// grab Eik variables from package.json
+const { eik: { server, files, type }, name } = packageJSON;
+
+// grab version directly from the dependency
+const version = packageJSON.dependencies[dependencyNameArg];
+
+const token = await eik.login({
+    server,
+    key: EIK_TOKEN,
+    logger: console,
+});
+
+await eik.publish({
+    cwd,
+    token,
+    server,
+    name,
+    type,
+    version,
+    files,
+    logger: console,
+});


### PR DESCRIPTION
What this adds:

* A renovate configuration script
* A custom node script to read the version of a dependency package and use it to publish to Eik
* A GH actions script to run the custom publish script