### PR TITLE
fix: use correct react version in build

### DIFF
--- a/packages/react-dom/rollup.config.js
+++ b/packages/react-dom/rollup.config.js
@@ -6,12 +6,12 @@ const { resolve } = createRequire(import.meta.url);
 const reactPkg = new URL("../react/package.json", import.meta.url);
 const reactDomPkg = new URL("./package.json", import.meta.url);
 
-const { name, main } = JSON.parse(fs.readFileSync(reactPkg.pathname, "utf8"));
-const { version } = JSON.parse(fs.readFileSync(reactDomPkg.pathname, "utf8"));
+const { name } = JSON.parse(fs.readFileSync(reactPkg.pathname, "utf8"));
+const { dependencies: { '@esm-bundle/react-dom': version } } = JSON.parse(fs.readFileSync(reactDomPkg.pathname, "utf8"));
 
 const importMap = {
   imports: {
-    react: `https://assets.finn.no/npm/${name}/${version}/${main}`,
+    react: `https://assets.finn.no/npm/${name}/${version}/react.production.min.js`,
   },
 };
 


### PR DESCRIPTION
**Why this change:**

After changing to make the publish script read directly from the dependency in the `package.json` dependencies field and setting the `package.json`'s `version` field to `0.0.0` I had forgotten to fix this build. 

**What this does:**

This PR changes the rollup build for react-dom to read the React `version` from the `react-dom` `dependencies` field to ensure that the version between `react` and `react-dom` are in lock step and is correct.