### PR TITLE
feat: add lit-html

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,8 @@
         "packages/fabric-elements",
         "packages/fabric-vue",
         "packages/fabric-react",
-        "packages/lit-element"
+        "packages/lit-element",
+        "packages/lit-html"
       ]
     },
     "node_modules/@babel/code-frame": {
@@ -2485,6 +2486,10 @@
       "resolved": "packages/lit-element",
       "link": true
     },
+    "node_modules/test-lit-html": {
+      "resolved": "packages/lit-html",
+      "link": true
+    },
     "node_modules/test-react": {
       "resolved": "packages/react",
       "link": true
@@ -2941,6 +2946,22 @@
       "license": "ISC",
       "dependencies": {
         "lit-element": "3.0.2"
+      },
+      "devDependencies": {
+        "@eik/cli": "2.0.16",
+        "@eik/rollup-plugin": "4.0.9",
+        "@rollup/plugin-commonjs": "21.0.1",
+        "@rollup/plugin-node-resolve": "13.0.6",
+        "rollup": "2.60.1",
+        "rollup-plugin-terser": "7.0.2"
+      }
+    },
+    "packages/lit-html": {
+      "name": "test-lit-html",
+      "version": "0.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "lit-html": "2.0.2"
       },
       "devDependencies": {
         "@eik/cli": "2.0.16",
@@ -4959,6 +4980,18 @@
         "@rollup/plugin-commonjs": "21.0.1",
         "@rollup/plugin-node-resolve": "13.0.6",
         "lit-element": "3.0.2",
+        "rollup": "2.60.1",
+        "rollup-plugin-terser": "7.0.2"
+      }
+    },
+    "test-lit-html": {
+      "version": "file:packages/lit-html",
+      "requires": {
+        "@eik/cli": "2.0.16",
+        "@eik/rollup-plugin": "4.0.9",
+        "@rollup/plugin-commonjs": "21.0.1",
+        "@rollup/plugin-node-resolve": "13.0.6",
+        "lit-html": "2.0.2",
         "rollup": "2.60.1",
         "rollup-plugin-terser": "7.0.2"
       }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "packages/fabric-elements",
     "packages/fabric-vue",
     "packages/fabric-react",
-    "packages/lit-element"
+    "packages/lit-element",
+    "packages/lit-html"
   ]
 }

--- a/packages/lit-html/package.json
+++ b/packages/lit-html/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "test-lit-html",
+  "version": "0.0.0",
+  "main": "index.js",
+  "scripts": {
+    "build": "npx rollup -c",
+    "eik:login": "eik login",
+    "eik:publish": "eik publish",
+    "eik:alias": "eik npm-alias",
+    "eik:publish:ci": "../../scripts/publish.js lit-html lit-html"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/finn-no/eik-shared-libs.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/finn-no/eik-shared-libs/issues"
+  },
+  "homepage": "https://github.com/finn-no/eik-shared-libs#readme",
+  "description": "",
+  "dependencies": {
+    "lit-html": "2.0.2"
+  },
+  "devDependencies": {
+    "@eik/cli": "2.0.16",
+    "@eik/rollup-plugin": "4.0.9",
+    "@rollup/plugin-commonjs": "21.0.1",
+    "@rollup/plugin-node-resolve": "13.0.6",
+    "rollup": "2.60.1",
+    "rollup-plugin-terser": "7.0.2"
+  },
+  "eik": {
+    "server": "https://assets.finn.no",
+    "type": "npm",
+    "files": "./dist"
+  }
+}

--- a/packages/lit-html/rollup.config.js
+++ b/packages/lit-html/rollup.config.js
@@ -1,0 +1,26 @@
+import { createRequire } from "module";
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import { terser } from 'rollup-plugin-terser';
+import commonjs from '@rollup/plugin-commonjs';
+
+const { resolve } = createRequire(import.meta.url);
+
+export default {
+  input: resolve("lit-html"),
+  output: {
+    format: "esm",
+    sourcemap: true,
+    file: `./dist/lit-html.min.js`,
+  },
+  plugins: [
+    nodeResolve(),
+    commonjs({
+        include: /node_modules/,
+    }),
+    terser({
+        format: {
+            comments: false,
+        },
+    }),
+  ],
+};

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,10 @@
         {
           "groupName": "React and TrackJS packages",
           "packageNames": ["@esm-bundle/react", "@esm-bundle/react-dom", "trackjs"]
+        },
+        {
+          "groupName": "Lit packages",
+          "packageNames": ["lit-html", "lit-element"]
         }
       ]
   }


### PR DESCRIPTION
Adds Lit HTML to the monorepo.

Lit Element is 16kb minified and Lit HTML is 7kb. 

I considered trying to optimise where Lit Element imports Lit HTML via Eik so that Lit Element would reduce in size to (I assume) 9kbish but I'm not convinced its worth it for 2 reasons:
* We would always need to preload lit-html any time we use lit-element or suffer the esm waterfall load effect
* We would need to depend on the exact version of lit-html that is declared in the lit-element package's package.json dependencies and this version might not be the same version that is our latest aliased version of lit-html in use which:
  a. would defeat the optimisation
  b. would make things more complicated for publishing.

In other words, the value didn't seem there for 7kb. 