### PR TITLE
refactor: add copy script to auto locate node_modules and copy into dist dir

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,6 +22,9 @@ jobs:
       - name: Run Build
         run: |
           npm run build
+      - name: Run Copy
+        run: |
+          npm run copy
       - name: Run Publish
         run: |
           npm run eik:publish:ci

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,11 @@
         "packages/fabric-react",
         "packages/lit-element",
         "packages/lit-html"
-      ]
+      ],
+      "devDependencies": {
+        "@eik/cli": "2.0.16",
+        "findup-sync": "^5.0.0"
+      }
     },
     "node_modules/@babel/code-frame": {
       "version": "7.16.0",
@@ -117,17 +121,6 @@
       },
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/@babel/parser": {
-      "version": "7.16.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
-      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng==",
-      "bin": {
-        "parser": "bin/babel-parser.js"
-      },
-      "engines": {
-        "node": ">=6.0.0"
       }
     },
     "node_modules/@eik/cli": {
@@ -314,112 +307,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
-    },
-    "node_modules/@vue/compiler-core": {
-      "version": "3.2.23",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.23.tgz",
-      "integrity": "sha512-4ZhiI/orx+7EJ1B+0zjgvXMV2uRN+XBfG06UN2sJfND9rH5gtEQT3QmO4erum1o6Irl7y754W8/KSaDJh4EUQg==",
-      "dependencies": {
-        "@babel/parser": "^7.15.0",
-        "@vue/shared": "3.2.23",
-        "estree-walker": "^2.0.2",
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/@vue/compiler-core/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@vue/compiler-dom": {
-      "version": "3.2.23",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.23.tgz",
-      "integrity": "sha512-X2Nw8QFc5lgoK3kio5ktM95nqmLUH+q+N/PbV4kCHzF1avqv/EGLnAhaaF0Iu4bewNvHJAAhhwPZFeoV/22nbw==",
-      "dependencies": {
-        "@vue/compiler-core": "3.2.23",
-        "@vue/shared": "3.2.23"
-      }
-    },
-    "node_modules/@vue/compiler-sfc": {
-      "version": "3.2.23",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.23.tgz",
-      "integrity": "sha512-Aw+pb50Q5zTjyvWod8mNKmYZDRGHJBptmNNWE+84ZxrzEztPgMz8cNYIzWGbwcFVkmJlhvioAMvKnB+LM/sjSA==",
-      "dependencies": {
-        "@babel/parser": "^7.15.0",
-        "@vue/compiler-core": "3.2.23",
-        "@vue/compiler-dom": "3.2.23",
-        "@vue/compiler-ssr": "3.2.23",
-        "@vue/ref-transform": "3.2.23",
-        "@vue/shared": "3.2.23",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.25.7",
-        "postcss": "^8.1.10",
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/@vue/compiler-sfc/node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@vue/compiler-ssr": {
-      "version": "3.2.23",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.23.tgz",
-      "integrity": "sha512-Bqzn4jFyXPK1Ehqiq7e/czS8n62gtYF1Zfeu0DrR5uv+SBllh7LIvZjZU6+c8qbocAd3/T3I3gn2cZGmnDb6zg==",
-      "dependencies": {
-        "@vue/compiler-dom": "3.2.23",
-        "@vue/shared": "3.2.23"
-      }
-    },
-    "node_modules/@vue/reactivity": {
-      "version": "3.2.23",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.23.tgz",
-      "integrity": "sha512-8RGVr/5Kpgb/EkCjgHXqttgA5IMc6n0lIXFY4TVbMkzdXrvaIhzBd7Te44oIDsTSYVKZLpfHd6/wEnuDqE8vFw==",
-      "dependencies": {
-        "@vue/shared": "3.2.23"
-      }
-    },
-    "node_modules/@vue/ref-transform": {
-      "version": "3.2.23",
-      "resolved": "https://registry.npmjs.org/@vue/ref-transform/-/ref-transform-3.2.23.tgz",
-      "integrity": "sha512-gW0GD2PSAs/th7mC7tPB/UwpIQxclbApVtsDtscDmOJXb2+cdu60ny+SuHNgfrlUT/JqWKQHq7jFKO4woxLNaA==",
-      "dependencies": {
-        "@babel/parser": "^7.15.0",
-        "@vue/compiler-core": "3.2.23",
-        "@vue/shared": "3.2.23",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.25.7"
-      }
-    },
-    "node_modules/@vue/runtime-core": {
-      "version": "3.2.23",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.23.tgz",
-      "integrity": "sha512-wSI5lmY2kCGLf89iiygqxVh6/5bsawz78Me9n1x4U2bHnN0yf3PWyuhN0WgIE8VfEaF7e75E333uboNEIFjgkg==",
-      "dependencies": {
-        "@vue/reactivity": "3.2.23",
-        "@vue/shared": "3.2.23"
-      }
-    },
-    "node_modules/@vue/runtime-dom": {
-      "version": "3.2.23",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.23.tgz",
-      "integrity": "sha512-z6lp0888NkLmxD9j2sGoll8Kb7J743s8s6w7GbiyUc4WZwm0KJ35B4qTFDMoIU0G7CatS6Z+yRTpPHc6srtByg==",
-      "dependencies": {
-        "@vue/runtime-core": "3.2.23",
-        "@vue/shared": "3.2.23",
-        "csstype": "^2.6.8"
-      }
-    },
-    "node_modules/@vue/shared": {
-      "version": "3.2.23",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.23.tgz",
-      "integrity": "sha512-U+/Jefa0QfXUF2qVy9Dqlrb6HKJSr9/wJcM66wXmWcTOoqg7hOWzF4qruDle51pyF4x3wMn6TSH54UdjKjCKMA=="
     },
     "node_modules/abslog": {
       "version": "2.4.0",
@@ -616,6 +503,18 @@
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "dependencies": {
+        "fill-range": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/buffer": {
@@ -855,11 +754,6 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
-    "node_modules/csstype": {
-      "version": "2.6.19",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
-      "integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ=="
-    },
     "node_modules/date-fns": {
       "version": "2.26.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.26.0.tgz",
@@ -912,6 +806,15 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/detect-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/duplexer": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
@@ -954,7 +857,8 @@
     "node_modules/estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
     },
     "node_modules/expand-tilde": {
       "version": "1.2.2",
@@ -1023,6 +927,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -1037,6 +953,85 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/findup-sync": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-5.0.0.tgz",
+      "integrity": "sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==",
+      "dev": true,
+      "dependencies": {
+        "detect-file": "^1.0.0",
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.4",
+        "resolve-dir": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+      "dev": true,
+      "dependencies": {
+        "homedir-polyfill": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/global-modules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "dev": true,
+      "dependencies": {
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/global-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+      "dev": true,
+      "dependencies": {
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/findup-sync/node_modules/resolve-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+      "dev": true,
+      "dependencies": {
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/form-data": {
@@ -1475,6 +1470,15 @@
       "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
       "dev": true
     },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
     "node_modules/is-reference": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -1702,6 +1706,7 @@
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
       "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
       "dependencies": {
         "sourcemap-codec": "^1.4.4"
       }
@@ -1755,6 +1760,19 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "dev": true,
+      "dependencies": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.2.3"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
     },
     "node_modules/mime-db": {
       "version": "1.51.0",
@@ -1836,17 +1854,6 @@
       },
       "bin": {
         "mkdirp": "bin/cmd.js"
-      }
-    },
-    "node_modules/nanoid": {
-      "version": "3.1.30",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ==",
-      "bin": {
-        "nanoid": "bin/nanoid.cjs"
-      },
-      "engines": {
-        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
     "node_modules/node-fetch": {
@@ -2016,11 +2023,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
-    "node_modules/picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
-    },
     "node_modules/picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -2043,23 +2045,6 @@
       },
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/postcss": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.1.tgz",
-      "integrity": "sha512-WqLs/TTzXdG+/A4ZOOK9WDZiikrRaiA+eoEb/jz2DT9KUhMNHgP7yKPO8vwi62ZCsb703Gwb7BMZwDzI54Y2Ag==",
-      "dependencies": {
-        "nanoid": "^3.1.30",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.1"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/postcss/"
       }
     },
     "node_modules/process-nextick-args": {
@@ -2425,14 +2410,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/source-map-js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
-      "integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA==",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -2455,7 +2432,8 @@
     "node_modules/sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "node_modules/spdx-correct": {
       "version": "3.1.1",
@@ -2799,6 +2777,18 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -3108,7 +3098,6 @@
         "lit-element": "3.0.2"
       },
       "devDependencies": {
-        "@eik/cli": "2.0.16",
         "@eik/rollup-plugin": "4.0.9",
         "@rollup/plugin-commonjs": "21.0.1",
         "@rollup/plugin-node-resolve": "13.0.6",
@@ -3124,7 +3113,6 @@
         "lit-html": "2.0.2"
       },
       "devDependencies": {
-        "@eik/cli": "2.0.16",
         "@eik/rollup-plugin": "4.0.9",
         "@rollup/plugin-commonjs": "21.0.1",
         "@rollup/plugin-node-resolve": "13.0.6",
@@ -3138,9 +3126,6 @@
       "license": "ISC",
       "dependencies": {
         "@esm-bundle/react": "17.0.1"
-      },
-      "devDependencies": {
-        "@eik/cli": "2.0.16"
       }
     },
     "packages/react-dom": {
@@ -3152,7 +3137,6 @@
         "@esm-bundle/react-dom": "17.0.1"
       },
       "devDependencies": {
-        "@eik/cli": "2.0.16",
         "@eik/rollup-plugin": "4.0.9",
         "rollup": "2.60.1"
       }
@@ -3162,9 +3146,6 @@
       "license": "ISC",
       "dependencies": {
         "trackjs": "3.10.1"
-      },
-      "devDependencies": {
-        "@eik/cli": "2.0.16"
       }
     },
     "packages/trackjs/node_modules/trackjs": {
@@ -3177,9 +3158,6 @@
       "license": "ISC",
       "dependencies": {
         "vue": "2.6.14"
-      },
-      "devDependencies": {
-        "@eik/cli": "2.0.16"
       }
     },
     "packages/vue-next": {
@@ -3188,15 +3166,11 @@
       "license": "ISC",
       "dependencies": {
         "vue": "3.2.23"
-      },
-      "devDependencies": {
-        "@eik/cli": "2.0.16"
       }
     },
     "packages/vue-next/node_modules/@vue/server-renderer": {
       "version": "3.2.23",
-      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.23.tgz",
-      "integrity": "sha512-mgQ2VAE5WjeZELJKNbwE69uiBNpN+3LyL0ZDki1bJWVwHD2fhPfx7pwyYuiucE81xz2LxVsyGxhKKUL997g8vw==",
+      "license": "MIT",
       "dependencies": {
         "@vue/compiler-ssr": "3.2.23",
         "@vue/shared": "3.2.23"
@@ -3207,8 +3181,7 @@
     },
     "packages/vue-next/node_modules/vue": {
       "version": "3.2.23",
-      "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.23.tgz",
-      "integrity": "sha512-MGp9JZC37lzGhwSu6c1tQxrQbXbw7XKFqtYh7SFwNrNK899FPxGAHwSHMZijMChTSC3uZrD2BGO/3EHOgMJ0cw==",
+      "license": "MIT",
       "dependencies": {
         "@vue/compiler-dom": "3.2.23",
         "@vue/compiler-sfc": "3.2.23",
@@ -3296,11 +3269,6 @@
           }
         }
       }
-    },
-    "@babel/parser": {
-      "version": "7.16.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.4.tgz",
-      "integrity": "sha512-6V0qdPUaiVHH3RtZeLIsc+6pDhbYzHR8ogA8w+f+Wc77DuXto19g2QUwveINoS34Uw+W8/hQDGJCx+i4n7xcng=="
     },
     "@eik/cli": {
       "version": "2.0.16",
@@ -3529,110 +3497,6 @@
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
     },
-    "@vue/compiler-core": {
-      "version": "3.2.23",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.2.23.tgz",
-      "integrity": "sha512-4ZhiI/orx+7EJ1B+0zjgvXMV2uRN+XBfG06UN2sJfND9rH5gtEQT3QmO4erum1o6Irl7y754W8/KSaDJh4EUQg==",
-      "requires": {
-        "@babel/parser": "^7.15.0",
-        "@vue/shared": "3.2.23",
-        "estree-walker": "^2.0.2",
-        "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
-      }
-    },
-    "@vue/compiler-dom": {
-      "version": "3.2.23",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.2.23.tgz",
-      "integrity": "sha512-X2Nw8QFc5lgoK3kio5ktM95nqmLUH+q+N/PbV4kCHzF1avqv/EGLnAhaaF0Iu4bewNvHJAAhhwPZFeoV/22nbw==",
-      "requires": {
-        "@vue/compiler-core": "3.2.23",
-        "@vue/shared": "3.2.23"
-      }
-    },
-    "@vue/compiler-sfc": {
-      "version": "3.2.23",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.2.23.tgz",
-      "integrity": "sha512-Aw+pb50Q5zTjyvWod8mNKmYZDRGHJBptmNNWE+84ZxrzEztPgMz8cNYIzWGbwcFVkmJlhvioAMvKnB+LM/sjSA==",
-      "requires": {
-        "@babel/parser": "^7.15.0",
-        "@vue/compiler-core": "3.2.23",
-        "@vue/compiler-dom": "3.2.23",
-        "@vue/compiler-ssr": "3.2.23",
-        "@vue/ref-transform": "3.2.23",
-        "@vue/shared": "3.2.23",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.25.7",
-        "postcss": "^8.1.10",
-        "source-map": "^0.6.1"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.6.1",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-        }
-      }
-    },
-    "@vue/compiler-ssr": {
-      "version": "3.2.23",
-      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.2.23.tgz",
-      "integrity": "sha512-Bqzn4jFyXPK1Ehqiq7e/czS8n62gtYF1Zfeu0DrR5uv+SBllh7LIvZjZU6+c8qbocAd3/T3I3gn2cZGmnDb6zg==",
-      "requires": {
-        "@vue/compiler-dom": "3.2.23",
-        "@vue/shared": "3.2.23"
-      }
-    },
-    "@vue/reactivity": {
-      "version": "3.2.23",
-      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.2.23.tgz",
-      "integrity": "sha512-8RGVr/5Kpgb/EkCjgHXqttgA5IMc6n0lIXFY4TVbMkzdXrvaIhzBd7Te44oIDsTSYVKZLpfHd6/wEnuDqE8vFw==",
-      "requires": {
-        "@vue/shared": "3.2.23"
-      }
-    },
-    "@vue/ref-transform": {
-      "version": "3.2.23",
-      "resolved": "https://registry.npmjs.org/@vue/ref-transform/-/ref-transform-3.2.23.tgz",
-      "integrity": "sha512-gW0GD2PSAs/th7mC7tPB/UwpIQxclbApVtsDtscDmOJXb2+cdu60ny+SuHNgfrlUT/JqWKQHq7jFKO4woxLNaA==",
-      "requires": {
-        "@babel/parser": "^7.15.0",
-        "@vue/compiler-core": "3.2.23",
-        "@vue/shared": "3.2.23",
-        "estree-walker": "^2.0.2",
-        "magic-string": "^0.25.7"
-      }
-    },
-    "@vue/runtime-core": {
-      "version": "3.2.23",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.2.23.tgz",
-      "integrity": "sha512-wSI5lmY2kCGLf89iiygqxVh6/5bsawz78Me9n1x4U2bHnN0yf3PWyuhN0WgIE8VfEaF7e75E333uboNEIFjgkg==",
-      "requires": {
-        "@vue/reactivity": "3.2.23",
-        "@vue/shared": "3.2.23"
-      }
-    },
-    "@vue/runtime-dom": {
-      "version": "3.2.23",
-      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.2.23.tgz",
-      "integrity": "sha512-z6lp0888NkLmxD9j2sGoll8Kb7J743s8s6w7GbiyUc4WZwm0KJ35B4qTFDMoIU0G7CatS6Z+yRTpPHc6srtByg==",
-      "requires": {
-        "@vue/runtime-core": "3.2.23",
-        "@vue/shared": "3.2.23",
-        "csstype": "^2.6.8"
-      }
-    },
-    "@vue/shared": {
-      "version": "3.2.23",
-      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.2.23.tgz",
-      "integrity": "sha512-U+/Jefa0QfXUF2qVy9Dqlrb6HKJSr9/wJcM66wXmWcTOoqg7hOWzF4qruDle51pyF4x3wMn6TSH54UdjKjCKMA=="
-    },
     "abslog": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/abslog/-/abslog-2.4.0.tgz",
@@ -3775,6 +3639,15 @@
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
+      }
+    },
+    "braces": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+      "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+      "dev": true,
+      "requires": {
+        "fill-range": "^7.0.1"
       }
     },
     "buffer": {
@@ -3945,11 +3818,6 @@
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
       "dev": true
     },
-    "csstype": {
-      "version": "2.6.19",
-      "resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.19.tgz",
-      "integrity": "sha512-ZVxXaNy28/k3kJg0Fou5MiYpp88j7H9hLZp8PDC3jV0WFjfH5E9xHb56L0W59cPbKbcHXeP4qyT8PrHp8t6LcQ=="
-    },
     "date-fns": {
       "version": "2.26.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.26.0.tgz",
@@ -3984,6 +3852,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
+    },
+    "detect-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "integrity": "sha1-8NZtA2cqglyxtzvbP+YjEMjlUrc=",
       "dev": true
     },
     "duplexer": {
@@ -4022,7 +3896,8 @@
     "estree-walker": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
-      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true
     },
     "expand-tilde": {
       "version": "1.2.2",
@@ -4079,6 +3954,15 @@
         "through2": "^2.0.1"
       }
     },
+    "fill-range": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+      "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+      "dev": true,
+      "requires": {
+        "to-regex-range": "^5.0.1"
+      }
+    },
     "find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -4087,6 +3971,69 @@
       "requires": {
         "locate-path": "^6.0.0",
         "path-exists": "^4.0.0"
+      }
+    },
+    "findup-sync": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-5.0.0.tgz",
+      "integrity": "sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==",
+      "dev": true,
+      "requires": {
+        "detect-file": "^1.0.0",
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.4",
+        "resolve-dir": "^1.0.1"
+      },
+      "dependencies": {
+        "expand-tilde": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+          "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
+          "dev": true,
+          "requires": {
+            "homedir-polyfill": "^1.0.1"
+          }
+        },
+        "global-modules": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+          "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+          "dev": true,
+          "requires": {
+            "global-prefix": "^1.0.1",
+            "is-windows": "^1.0.1",
+            "resolve-dir": "^1.0.0"
+          }
+        },
+        "global-prefix": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+          "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
+          "dev": true,
+          "requires": {
+            "expand-tilde": "^2.0.2",
+            "homedir-polyfill": "^1.0.1",
+            "ini": "^1.3.4",
+            "is-windows": "^1.0.1",
+            "which": "^1.2.14"
+          }
+        },
+        "is-windows": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+          "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+          "dev": true
+        },
+        "resolve-dir": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+          "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
+          "dev": true,
+          "requires": {
+            "expand-tilde": "^2.0.0",
+            "global-modules": "^1.0.0"
+          }
+        }
       }
     },
     "form-data": {
@@ -4419,6 +4366,12 @@
       "integrity": "sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=",
       "dev": true
     },
+    "is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true
+    },
     "is-reference": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/is-reference/-/is-reference-1.2.1.tgz",
@@ -4598,6 +4551,7 @@
       "version": "0.25.7",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz",
       "integrity": "sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==",
+      "dev": true,
       "requires": {
         "sourcemap-codec": "^1.4.4"
       }
@@ -4641,6 +4595,16 @@
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
       "dev": true
+    },
+    "micromatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.4.tgz",
+      "integrity": "sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==",
+      "dev": true,
+      "requires": {
+        "braces": "^3.0.1",
+        "picomatch": "^2.2.3"
+      }
     },
     "mime-db": {
       "version": "1.51.0",
@@ -4702,11 +4666,6 @@
       "requires": {
         "minimist": "^1.2.5"
       }
-    },
-    "nanoid": {
-      "version": "3.1.30",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.1.30.tgz",
-      "integrity": "sha512-zJpuPDwOv8D2zq2WRoMe1HsfZthVewpel9CAvTfc/2mBD1uUT/agc5f7GHGWXlYkFvi1mVxe4IjvP2HNrop7nQ=="
     },
     "node-fetch": {
       "version": "2.6.6",
@@ -4827,11 +4786,6 @@
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
-    "picocolors": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
-      "integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
-    },
     "picomatch": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
@@ -4845,16 +4799,6 @@
       "dev": true,
       "requires": {
         "find-up": "^5.0.0"
-      }
-    },
-    "postcss": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.1.tgz",
-      "integrity": "sha512-WqLs/TTzXdG+/A4ZOOK9WDZiikrRaiA+eoEb/jz2DT9KUhMNHgP7yKPO8vwi62ZCsb703Gwb7BMZwDzI54Y2Ag==",
-      "requires": {
-        "nanoid": "^3.1.30",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.1"
       }
     },
     "process-nextick-args": {
@@ -5102,11 +5046,6 @@
       "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
       "dev": true
     },
-    "source-map-js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.1.tgz",
-      "integrity": "sha512-4+TN2b3tqOCd/kaGRJ/sTYA0tR0mdXx26ipdolxcwtJVqEnqNYvlCAt1q3ypy4QMlYus+Zh34RNtYLoq2oQ4IA=="
-    },
     "source-map-support": {
       "version": "0.5.21",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
@@ -5128,7 +5067,8 @@
     "sourcemap-codec": {
       "version": "1.4.8",
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA=="
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "spdx-correct": {
       "version": "3.1.1",
@@ -5273,7 +5213,6 @@
     "test-lit-element": {
       "version": "file:packages/lit-element",
       "requires": {
-        "@eik/cli": "2.0.16",
         "@eik/rollup-plugin": "4.0.9",
         "@rollup/plugin-commonjs": "21.0.1",
         "@rollup/plugin-node-resolve": "13.0.6",
@@ -5285,7 +5224,6 @@
     "test-lit-html": {
       "version": "file:packages/lit-html",
       "requires": {
-        "@eik/cli": "2.0.16",
         "@eik/rollup-plugin": "4.0.9",
         "@rollup/plugin-commonjs": "21.0.1",
         "@rollup/plugin-node-resolve": "13.0.6",
@@ -5297,14 +5235,12 @@
     "test-react": {
       "version": "file:packages/react",
       "requires": {
-        "@eik/cli": "2.0.16",
         "@esm-bundle/react": "17.0.1"
       }
     },
     "test-react-dom": {
       "version": "file:packages/react-dom",
       "requires": {
-        "@eik/cli": "2.0.16",
         "@eik/rollup-plugin": "4.0.9",
         "@esm-bundle/react-dom": "17.0.1",
         "rollup": "2.60.1"
@@ -5313,21 +5249,17 @@
     "test-vue": {
       "version": "file:packages/vue",
       "requires": {
-        "@eik/cli": "2.0.16",
         "vue": "2.6.14"
       }
     },
     "test-vue-next": {
       "version": "file:packages/vue-next",
       "requires": {
-        "@eik/cli": "2.0.16",
         "vue": "3.2.23"
       },
       "dependencies": {
         "@vue/server-renderer": {
           "version": "3.2.23",
-          "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.2.23.tgz",
-          "integrity": "sha512-mgQ2VAE5WjeZELJKNbwE69uiBNpN+3LyL0ZDki1bJWVwHD2fhPfx7pwyYuiucE81xz2LxVsyGxhKKUL997g8vw==",
           "requires": {
             "@vue/compiler-ssr": "3.2.23",
             "@vue/shared": "3.2.23"
@@ -5335,8 +5267,6 @@
         },
         "vue": {
           "version": "3.2.23",
-          "resolved": "https://registry.npmjs.org/vue/-/vue-3.2.23.tgz",
-          "integrity": "sha512-MGp9JZC37lzGhwSu6c1tQxrQbXbw7XKFqtYh7SFwNrNK899FPxGAHwSHMZijMChTSC3uZrD2BGO/3EHOgMJ0cw==",
           "requires": {
             "@vue/compiler-dom": "3.2.23",
             "@vue/compiler-sfc": "3.2.23",
@@ -5469,6 +5399,15 @@
         }
       }
     },
+    "to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "requires": {
+        "is-number": "^7.0.0"
+      }
+    },
     "tr46": {
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
@@ -5477,7 +5416,6 @@
     "trackjs": {
       "version": "file:packages/trackjs",
       "requires": {
-        "@eik/cli": "2.0.16",
         "trackjs": "3.10.1"
       },
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -22,5 +22,9 @@
     "packages/fabric-react",
     "packages/lit-element",
     "packages/lit-html"
-  ]
+  ],
+  "devDependencies": {
+    "@eik/cli": "2.0.16",
+    "findup-sync": "5.0.0"
+  }
 }

--- a/packages/fabric-css/package.json
+++ b/packages/fabric-css/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "echo \"No build command installed\"",
+    "copy": "../../scripts/copy.js fabric-css @fabric-ds/css dist/fabric.min.css",
     "eik:login": "eik login",
     "eik:publish": "eik publish",
     "eik:alias": "eik npm-alias",
@@ -24,7 +25,7 @@
   "eik": {
     "server": "https://assets.finn.no",
     "type": "npm",
-    "files": "./node_modules/@fabric-ds/css/dist"
+    "files": "dist"
   },
   "dependencies": {
     "@fabric-ds/css": "1.0.2"

--- a/packages/fabric-elements/package.json
+++ b/packages/fabric-elements/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "echo \"No build command installed\"",
+    "copy": "../../scripts/copy.js fabric-elements @fabric-ds/elements dist/*",
     "eik:login": "eik login",
     "eik:publish": "eik publish",
     "eik:alias": "eik npm-alias",
@@ -27,6 +28,6 @@
   "eik": {
     "server": "https://assets.finn.no",
     "type": "npm",
-    "files": "./node_modules/@fabric-ds/elements/dist"
+    "files": "dist"
   }
 }

--- a/packages/fabric-react/package.json
+++ b/packages/fabric-react/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "echo \"No build command installed\"",
+    "copy": "../../scripts/copy.js fabric-react @fabric-ds/react dist/npm/*",
     "eik:login": "eik login",
     "eik:publish": "eik publish",
     "eik:alias": "eik npm-alias",
@@ -27,6 +28,6 @@
   "eik": {
     "server": "https://assets.finn.no",
     "type": "npm",
-    "files": "./node_modules/@fabric-ds/react/dist"
+    "files": "dist"
   }
 }

--- a/packages/fabric-vue/package.json
+++ b/packages/fabric-vue/package.json
@@ -5,6 +5,7 @@
   "main": "index.js",
   "scripts": {
     "build": "echo \"No build command installed\"",
+    "copy": "../../scripts/copy.js fabric-vue @fabric-ds/vue dist/eik/*",
     "eik:login": "eik login",
     "eik:publish": "eik publish",
     "eik:alias": "eik npm-alias",
@@ -27,6 +28,6 @@
   "eik": {
     "server": "https://assets.finn.no",
     "type": "npm",
-    "files": "./node_modules/@fabric-ds/vue/dist/eik"
+    "files": "dist"
   }
 }

--- a/packages/lit-element/package.json
+++ b/packages/lit-element/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "scripts": {
     "build": "npx rollup -c",
+    "copy": "echo \"No copy command installed\"",
     "eik:login": "eik login",
     "eik:publish": "eik publish",
     "eik:alias": "eik npm-alias",
@@ -25,7 +26,6 @@
     "lit-element": "3.0.2"
   },
   "devDependencies": {
-    "@eik/cli": "2.0.16",
     "@eik/rollup-plugin": "4.0.9",
     "@rollup/plugin-commonjs": "21.0.1",
     "@rollup/plugin-node-resolve": "13.0.6",
@@ -35,6 +35,6 @@
   "eik": {
     "server": "https://assets.finn.no",
     "type": "npm",
-    "files": "./dist"
+    "files": "dist"
   }
 }

--- a/packages/lit-html/package.json
+++ b/packages/lit-html/package.json
@@ -4,6 +4,7 @@
   "main": "index.js",
   "scripts": {
     "build": "npx rollup -c",
+    "copy": "echo \"No copy command installed\"",
     "eik:login": "eik login",
     "eik:publish": "eik publish",
     "eik:alias": "eik npm-alias",
@@ -25,7 +26,6 @@
     "lit-html": "2.0.2"
   },
   "devDependencies": {
-    "@eik/cli": "2.0.16",
     "@eik/rollup-plugin": "4.0.9",
     "@rollup/plugin-commonjs": "21.0.1",
     "@rollup/plugin-node-resolve": "13.0.6",
@@ -35,6 +35,6 @@
   "eik": {
     "server": "https://assets.finn.no",
     "type": "npm",
-    "files": "./dist"
+    "files": "dist"
   }
 }

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "build": "npx rollup -c",
+    "copy": "echo \"No copy command installed\"",
     "eik:login": "eik login",
     "eik:publish": "eik publish",
     "eik:alias": "eik npm-alias",
@@ -19,16 +20,12 @@
     "@esm-bundle/react-dom": "17.0.1"
   },
   "devDependencies": {
-    "@eik/cli": "2.0.16",
     "@eik/rollup-plugin": "4.0.9",
     "rollup": "2.60.1"
   },
   "eik": {
     "server": "https://assets.finn.no",
     "type": "npm",
-    "files": {
-      "react-dom.production.min.js": "./dist/react-dom.production.min.js",
-      "react-dom.production.min.js.map": "./dist/react-dom.production.min.js.map"
-    }
+    "files": "dist"
   }
 }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -7,6 +7,7 @@
   "main": "react.production.min.js",
   "scripts": {
     "build": "echo \"No build command installed\"",
+    "copy": "../../scripts/copy.js react @esm-bundle/react esm/react.production.min.*",
     "eik:login": "eik login",
     "eik:publish": "eik publish",
     "eik:alias": "eik npm-alias",
@@ -17,15 +18,9 @@
   "dependencies": {
     "@esm-bundle/react": "17.0.1"
   },
-  "devDependencies": {
-    "@eik/cli": "2.0.16"
-  },
   "eik": {
     "server": "https://assets.finn.no",
     "type": "npm",
-    "files": {
-      "react.production.min.js": "../../node_modules/@esm-bundle/react/esm/react.production.min.js",
-      "react.production.min.js.map": "../../node_modules/@esm-bundle/react/esm/react.production.min.js.map"
-    }
+    "files": "dist"
   }
 }

--- a/packages/trackjs/package.json
+++ b/packages/trackjs/package.json
@@ -7,6 +7,7 @@
     "main": "trackjs.production.min.js",
     "scripts": {
         "build": "echo \"No build command installed\"",
+        "copy": "../../scripts/copy.js trackjs trackjs index.esm.js",
         "eik:login": "eik login",
         "eik:publish": "eik publish",
         "eik:alias": "eik npm-alias",
@@ -17,14 +18,11 @@
     "dependencies": {
         "trackjs": "3.10.1"
     },
-    "devDependencies": {
-        "@eik/cli": "2.0.16"
-    },
     "eik": {
         "server": "https://assets.finn.no",
         "type": "npm",
         "files": {
-            "trackjs.production.min.js": "./node_modules/trackjs/index.esm.js"
+            "trackjs.production.min.js": "./dist/index.esm.js"
         }
     }
 }

--- a/packages/vue-next/package.json
+++ b/packages/vue-next/package.json
@@ -5,6 +5,7 @@
   "main": "",
   "scripts": {
     "build": "echo \"No build command installed\"",
+    "copy": "../../scripts/copy.js vue-next vue dist/*.js",
     "eik:login": "eik login",
     "eik:publish": "eik publish",
     "eik:alias": "eik npm-alias",
@@ -23,12 +24,9 @@
   "eik": {
     "server": "https://assets.finn.no",
     "type": "npm",
-    "files": "./node_modules/vue/dist/*.js"
+    "files": "dist"
   },
   "dependencies": {
     "vue": "3.2.23"
-  },
-  "devDependencies": {
-    "@eik/cli": "2.0.16"
   }
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -5,6 +5,7 @@
   "main": "",
   "scripts": {
     "build": "echo \"No build command installed\"",
+    "copy": "../../scripts/copy.js vue vue dist/*.js",
     "eik:login": "eik login",
     "eik:publish": "eik publish",
     "eik:alias": "eik npm-alias",
@@ -23,12 +24,9 @@
   "eik": {
     "server": "https://assets.finn.no",
     "type": "npm",
-    "files": "../../node_modules/vue/dist/*.js"
+    "files": "dist"
   },
   "dependencies": {
     "vue": "2.6.14"
-  },
-  "devDependencies": {
-    "@eik/cli": "2.0.16"
   }
 }

--- a/scripts/copy.js
+++ b/scripts/copy.js
@@ -1,0 +1,31 @@
+#!/usr/bin/env node
+
+// Copy script for packages that don't use a rollup build.
+// Purpose of this script is to locate the correct node_modules folder
+// and copy the necessary files to a dist folder for uploading.
+
+// EXAMPLE USAGE
+// ./scripts/copy.js fabric-css @fabric-ds/css dist/fabric.min.css
+
+// ARGs (all required)
+// 1. package name eg. fabric-css
+// 2. dependency name eg. @fabric-ds/css
+// 3. dependency file or dir path eg. dist/fabric.min.css eg. dist/*
+
+import { join } from 'path';
+import findup from 'findup-sync';
+import { execSync } from 'child_process';
+
+const dirname = new URL('./', import.meta.url).pathname;
+const [, , packageNameArg, dependencyNameArg, dependencyFilePathArg] = process.argv;
+const cwd = join(dirname, '../packages', packageNameArg);
+
+// find closest node_modules folder. This might be in the package folder or at the monorepo root.
+const nodeModulesPath = findup(`node_modules`, { cwd }); 
+// build the dependency path from the closest node_modules folder
+const dependencyPath = join(nodeModulesPath, dependencyNameArg);
+
+// make directory if it doesn't already exist
+execSync(`mkdir -p ${join(cwd, 'dist')}`);
+// copy the dependency files to the packages dist folder ready for uploading
+execSync(`cp -R ${join(dependencyPath, dependencyFilePathArg)} ${join(cwd, 'dist/')}`);


### PR DESCRIPTION
Why?

Before this PR, location of node_modules folder was hard coded in publish commands and such. This is very brittle because we have no direct control over which node_modules folder npm will install into. If there is a clash then npm will place dependencies into the node_modules folder inside the package folder, otherwise it will place it in node_modules at the root level. 

Initially, I tried to do with using Node's own resolve mechanisms but they are limited to what has been defined in the package.json exports field. Some packages don't use these correctly and even if they do, each file has to be individually copied as you can't glob on a whole directory. Because of this, I ended up using the `findup-sync` package to locate the closest `node_modules` folder parent.

Each package then first either uses this script to copy the files needed for upload to a `dist` folder OR uses a rollup build to build into the `dist` folder. Eik then can just always upload whatever is in the `dist` folder.