### PR TITLE
chore: remove testing namespace, revert react to v16

### DIFF
--- a/packages/lit-element/package.json
+++ b/packages/lit-element/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test2-lit-element",
+  "name": "lit-element",
   "version": "0.0.0",
   "main": "index.js",
   "scripts": {

--- a/packages/lit-html/package.json
+++ b/packages/lit-html/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test2-lit-html",
+  "name": "lit-html",
   "version": "0.0.0",
   "main": "index.js",
   "scripts": {

--- a/packages/react-dom/package.json
+++ b/packages/react-dom/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test2-react-dom",
+  "name": "react-dom",
   "private": "true",
   "version": "0.0.0",
   "description": "An ESM version of React Dom for Finn",
@@ -17,7 +17,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@esm-bundle/react-dom": "17.0.1"
+    "@esm-bundle/react-dom": "16.14.0"
   },
   "devDependencies": {
     "@eik/rollup-plugin": "4.0.9",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test2-react",
+  "name": "react",
   "private": "true",
   "version": "0.0.0",
   "description": "An ESM version of React for Finn",
@@ -16,7 +16,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@esm-bundle/react": "17.0.1"
+    "@esm-bundle/react": "16.14.0"
   },
   "eik": {
     "server": "https://assets.finn.no",

--- a/packages/vue-next/package.json
+++ b/packages/vue-next/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test2-vue-next",
+  "name": "vue-next",
   "version": "0.0.0",
   "description": "An ESM version of Vue for Finn",
   "main": "",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "test2-vue",
+  "name": "vue",
   "version": "0.0.0",
   "description": "An ESM version of Vue for Finn",
   "main": "",


### PR DESCRIPTION
I've finished testing the various published packages and all seems well. This PR then removes the testing namespace from package names so that Eik will publish the final versions ready for use. I've also reverted React to the last v16 so that will be published and then renovate should update us back to v17 automatically.