### PR TITLE
feat: add main lit package

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "packages/trackjs",
     "packages/vue",
     "packages/vue-next",
+    "packages/lit",
     "packages/lit-element",
     "packages/lit-html",
     "packages/podium-browser"

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "lit",
+  "version": "0.0.0",
+  "main": "index.js",
+  "scripts": {
+    "build": "npx rollup -c",
+    "copy": "echo \"No copy command installed\"",
+    "eik:login": "eik login",
+    "eik:publish": "eik publish",
+    "eik:alias": "eik npm-alias",
+    "eik:publish:ci": "../../scripts/publish.js lit lit"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/finn-no/eik-shared-libs.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/finn-no/eik-shared-libs/issues"
+  },
+  "homepage": "https://github.com/finn-no/eik-shared-libs#readme",
+  "description": "",
+  "dependencies": {
+    "lit": "2.2.5"
+  },
+  "devDependencies": {
+    "@eik/rollup-plugin": "4.0.9",
+    "@rollup/plugin-commonjs": "21.0.1",
+    "@rollup/plugin-node-resolve": "13.1.2",
+    "rollup": "2.63.0",
+    "rollup-plugin-terser": "7.0.2"
+  },
+  "eik": {
+    "server": "https://assets.finn.no",
+    "type": "npm",
+    "files": "dist"
+  }
+}

--- a/packages/lit/rollup.config.js
+++ b/packages/lit/rollup.config.js
@@ -1,0 +1,26 @@
+import { createRequire } from "module";
+import { nodeResolve } from '@rollup/plugin-node-resolve';
+import { terser } from 'rollup-plugin-terser';
+import commonjs from '@rollup/plugin-commonjs';
+
+const { resolve } = createRequire(import.meta.url);
+
+export default {
+  input: resolve("lit"),
+  output: {
+    format: "esm",
+    sourcemap: true,
+    file: `./dist/lit.min.js`,
+  },
+  plugins: [
+    nodeResolve(),
+    commonjs({
+        include: /node_modules/,
+    }),
+    terser({
+        format: {
+            comments: false,
+        },
+    }),
+  ],
+};


### PR DESCRIPTION
We already have lit-html and lit-element packages in this repo but we were missing the top level lit package which imports lit-html and lit-element and is the preferred way to interface with Lit currently. This PR adds this top level lit package to our setup.

See: https://finn-jira.atlassian.net/browse/FRON-605