### PR TITLE
fix: add in missing lit subpath exports

### DIFF
--- a/packages/lit/index.js
+++ b/packages/lit/index.js
@@ -1,0 +1,32 @@
+export * from 'lit';
+export * from 'lit/async-directive.js';
+export * from 'lit/directive-helpers.js';
+export * from 'lit/directive.js';
+export * from 'lit/directives/async-append.js';
+export * from 'lit/directives/async-replace.js';
+export * from 'lit/directives/cache.js';
+export * from 'lit/directives/choose.js';
+export * from 'lit/directives/class-map.js';
+export * from 'lit/directives/guard.js';
+export * from 'lit/directives/if-defined.js';
+export * from 'lit/directives/join.js';
+export * from 'lit/directives/keyed.js';
+export * from 'lit/directives/live.js';
+export * from 'lit/directives/map.js';
+export * from 'lit/directives/range.js';
+export * from 'lit/directives/ref.js';
+export * from 'lit/directives/repeat.js';
+export * from 'lit/directives/style-map.js';
+export * from 'lit/directives/template-content.js';
+export * from 'lit/directives/unsafe-html.js';
+export * from 'lit/directives/unsafe-svg.js';
+export * from 'lit/directives/until.js';
+export * from 'lit/directives/when.js';
+
+export {
+  html as staticHtml,
+  literal,
+  svg as staticSvg,
+  unsafeStatic,
+  withStatic,
+} from 'lit/static-html.js';

--- a/packages/lit/rollup.config.js
+++ b/packages/lit/rollup.config.js
@@ -1,12 +1,9 @@
-import { createRequire } from "module";
 import { nodeResolve } from '@rollup/plugin-node-resolve';
 import { terser } from 'rollup-plugin-terser';
 import commonjs from '@rollup/plugin-commonjs';
 
-const { resolve } = createRequire(import.meta.url);
-
 export default {
-  input: resolve("lit"),
+  input: './index.js',
   output: {
     format: "esm",
     sourcemap: true,


### PR DESCRIPTION
Realised that while we were providing the core lit package, we weren't providing all the additional support tools (directives and decorators) that lit provides. In order to do so I needed to copy the file that lit has for defining an all in one bundle. You can see that here: https://github.com/lit/lit/blob/main/packages/lit/src/index.all.ts They don't export this so its not available to us when we install the package hence the need to copy paste.