### PR TITLE
ci: Rename packages to avoid naming collision with the dependencies

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,18 +15,18 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 18.x
       - name: Install Dependencies
         run: |
           npm install
       - name: Run Build
         run: |
-          npm run build -ws
+          npm run build
       - name: Run Copy
         run: |
-          npm run copy -ws
+          npm run copy
       - name: Run Publish
         run: |
-          npm run eik:publish:ci -ws
+          npm run publish
         env:
           EIK_TOKEN: ${{ secrets.EIK_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,49 @@
+# Eik Shared Libs
+
+This project is used to maintain up to date ESM versions of key shared libraries used at Finn.
+These are libraries whos versions we want to align teams on across the organisation in order to reduce their rebundling in applications.
+See the packages folder for the current complete list of libraries.
+
+## How it works
+
+Renovate bot is employed to update each library whenever new versions become available. PRs from Renovate are auto merged which kicks off a new build and publish for that library.
+After this, each new version will be available on Eik and after some time has passed (usually 1 week) we move the Eik alias for the library to the new version. This last part is 
+intentionally a manual process to help ensure bad builds don't break production apps.
+
+## Special Cases
+
+* React does not support ESM yet so we are forced to maintain an ESM build script for React
+* React DOM contains a reference to React (import react from "react") and we map this to an Eik version of React
+* Lit does not provide a "full" package export (even though they provide one on CDN) so we are forced to maintain a build script that includes the entirity of Lit packages in one
+
+## Development
+
+### Install
+
+Running `npm install` from the repo root will install all dependencies for all workspaces.
+
+### Scripts
+
+Build and copy scripts are maintained in the scripts folder. These are referenced and used for each of the workspaces.
+
+### Copy
+
+Each workspace includes a copy script in package.json scripts though for many, this is just a noop. The copy script is used for repos that don't need to build anything and can 
+simply copy lib files out of node_modules and place them in a dist folder for publishing to Eik.
+
+### Build
+
+Each workspace includes a build script in package.json scripts though for many, this is just a noop. The build script is used to run esbuild or rollup to produce an Eik friendly version. Libraries like Lit and React need to run builds since they do not provide a build in the state we need for publishing to Eik.
+
+### Publish
+
+Each workspace includes an eik:publish:ci run script in package.json scripts. This script will log into the Eik server and publish everything defined in the the package.json "eik" section for the workspace. This normally means that once copy and build are complete, a dist folder will contain files that the eik:publish:ci command will then upload.
+
+## CI
+
+Refer to the .github/workflows/publish.yml file for CI instructions. In short though, on CI the following commands are run:
+
+* Install: `npm install`
+* Build: `npm run build`
+* Copy: `npm run copy`
+* Publish: `npm run publish`

--- a/package.json
+++ b/package.json
@@ -1,15 +1,9 @@
 {
-  "name": "frontend-libraries",
-  "version": "1.0.0",
-  "description": "",
-  "main": "index.js",
+  "name": "@finn-no/frontend-libraries",
+  "version": "0.0.0",
+  "description": "Shared frontend libraries at FINN",
   "type": "module",
-  "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "workspaces": [
     "packages/react-17",
     "packages/react-dom-17",

--- a/package.json
+++ b/package.json
@@ -4,6 +4,11 @@
   "description": "Shared frontend libraries at FINN",
   "type": "module",
   "license": "MIT",
+  "scripts": {
+    "build": "npm run build -ws",
+    "copy": "npm run copy -ws",
+    "publish": "npm run eik:publish:ci -ws"
+  },
   "workspaces": [
     "packages/react-17",
     "packages/react-dom-17",

--- a/packages/lit-element/package.json
+++ b/packages/lit-element/package.json
@@ -1,28 +1,15 @@
 {
-  "name": "lit-element",
+  "name": "@finn-no/lit-element",
   "version": "0.0.0",
-  "main": "index.js",
+  "description": "An ESM version of Lit Element for Finn",
   "type": "module",
   "scripts": {
     "build": "node ./esbuild.js",
-    "copy": "echo \"No copy command installed\"",
     "eik:login": "eik login",
     "eik:publish": "eik publish",
     "eik:alias": "eik npm-alias",
     "eik:publish:ci": "../../scripts/publish.js lit-element lit-element"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/finn-no/eik-shared-libs.git"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/finn-no/eik-shared-libs/issues"
-  },
-  "homepage": "https://github.com/finn-no/eik-shared-libs#readme",
-  "description": "",
   "dependencies": {
     "lit-element": "3.2.2"
   },
@@ -30,6 +17,7 @@
     "esbuild": "0.15.14"
   },
   "eik": {
+    "name": "lit-element",
     "server": "https://assets.finn.no",
     "type": "npm",
     "files": "dist"

--- a/packages/lit-element/package.json
+++ b/packages/lit-element/package.json
@@ -4,6 +4,7 @@
   "description": "An ESM version of Lit Element for Finn",
   "type": "module",
   "scripts": {
+    "copy": "echo 'noop';",
     "build": "node ./esbuild.js",
     "eik:login": "eik login",
     "eik:publish": "eik publish",

--- a/packages/lit-html/package.json
+++ b/packages/lit-html/package.json
@@ -1,28 +1,15 @@
 {
-  "name": "lit-html",
+  "name": "@finn-no/lit-html",
   "version": "0.0.0",
-  "main": "index.js",
+  "description": "An ESM version of Lit HTML for Finn",
   "type": "module",
   "scripts": {
     "build": "node ./esbuild.js",
-    "copy": "echo \"No copy command installed\"",
     "eik:login": "eik login",
     "eik:publish": "eik publish",
     "eik:alias": "eik npm-alias",
     "eik:publish:ci": "../../scripts/publish.js lit-html lit-html"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/finn-no/eik-shared-libs.git"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/finn-no/eik-shared-libs/issues"
-  },
-  "homepage": "https://github.com/finn-no/eik-shared-libs#readme",
-  "description": "",
   "dependencies": {
     "lit-html": "2.4.0"
   },
@@ -30,6 +17,7 @@
     "esbuild": "0.15.14"
   },
   "eik": {
+    "name": "lit-html",
     "server": "https://assets.finn.no",
     "type": "npm",
     "files": "dist"

--- a/packages/lit-html/package.json
+++ b/packages/lit-html/package.json
@@ -4,6 +4,7 @@
   "description": "An ESM version of Lit HTML for Finn",
   "type": "module",
   "scripts": {
+    "copy": "echo 'noop';",
     "build": "node ./esbuild.js",
     "eik:login": "eik login",
     "eik:publish": "eik publish",

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -1,28 +1,15 @@
 {
-  "name": "lit",
+  "name": "@finn-no/lit",
   "version": "0.0.0",
-  "main": "index.js",
+  "description": "An ESM version of Lit for Finn",
   "type": "module",
   "scripts": {
     "build": "node ./esbuild.js",
-    "copy": "echo \"No copy command installed\"",
     "eik:login": "eik login",
     "eik:publish": "eik publish",
     "eik:alias": "eik npm-alias",
     "eik:publish:ci": "../../scripts/publish.js lit lit"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/finn-no/eik-shared-libs.git"
-  },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/finn-no/eik-shared-libs/issues"
-  },
-  "homepage": "https://github.com/finn-no/eik-shared-libs#readme",
-  "description": "",
   "dependencies": {
     "lit": "2.4.1"
   },
@@ -30,6 +17,7 @@
     "esbuild": "0.15.14"
   },
   "eik": {
+    "name": "lit",
     "server": "https://assets.finn.no",
     "type": "npm",
     "files": "dist"

--- a/packages/lit/package.json
+++ b/packages/lit/package.json
@@ -4,6 +4,7 @@
   "description": "An ESM version of Lit for Finn",
   "type": "module",
   "scripts": {
+    "copy": "echo 'noop';",
     "build": "node ./esbuild.js",
     "eik:login": "eik login",
     "eik:publish": "eik publish",

--- a/packages/podium-browser/esbuild.js
+++ b/packages/podium-browser/esbuild.js
@@ -1,7 +1,10 @@
+import { createRequire } from "node:module";
 import esbuild from "esbuild";
 
+const { resolve } = createRequire(import.meta.url);
+
 await esbuild.build({
-  entryPoints: ["./node_modules/@podium/browser/src/index.js"],
+  entryPoints: [resolve("@podium/browser")],
   bundle: true,
   minify: true,
   format: "esm",

--- a/packages/podium-browser/package.json
+++ b/packages/podium-browser/package.json
@@ -4,6 +4,7 @@
     "description": "An ESM version of @podium/browser for Finn",
     "type": "module",
     "scripts": {
+        "copy": "echo 'noop';",
         "build": "node ./esbuild.js",
         "eik:login": "eik login",
         "eik:publish": "eik publish",

--- a/packages/podium-browser/package.json
+++ b/packages/podium-browser/package.json
@@ -1,20 +1,15 @@
 {
-    "name": "@podium/browser",
-    "private": "true",
+    "name": "@finn-no/podium-browser",
     "version": "0.0.0",
     "description": "An ESM version of @podium/browser for Finn",
     "type": "module",
-    "main": "./dist/index.js",
     "scripts": {
         "build": "node ./esbuild.js",
-        "copy": "echo \"No copy command installed\"",
         "eik:login": "eik login",
         "eik:publish": "eik publish",
         "eik:alias": "eik npm-alias",
         "eik:publish:ci": "../../scripts/publish.js podium-browser @podium/browser"
     },
-    "author": "",
-    "license": "ISC",
     "dependencies": {
         "@podium/browser": "1.2.1"
     },
@@ -22,6 +17,7 @@
         "esbuild": "0.15.14"
     },
     "eik": {
+        "name": "@podium/browser",
         "server": "https://assets.finn.no",
         "type": "npm",
         "files": "dist"

--- a/packages/react-17/.npmrc
+++ b/packages/react-17/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/react-17/package.json
+++ b/packages/react-17/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "copy": "../../scripts/copy.js react-17 @esm-bundle/react esm/react.production.min.*",
+    "build": "echo 'noop';",
     "eik:login": "eik login",
     "eik:publish": "eik publish",
     "eik:alias": "eik npm-alias",

--- a/packages/react-17/package.json
+++ b/packages/react-17/package.json
@@ -1,20 +1,15 @@
 {
-  "name": "react-17",
-  "private": "true",
+  "name": "@finn-no/react-17",
   "version": "0.0.0",
-  "description": "An ESM version of React for Finn",
+  "description": "An ESM version of React 17 for Finn",
   "type": "module",
-  "main": "react.production.min.js",
   "scripts": {
-    "build": "echo \"No build command installed\"",
     "copy": "../../scripts/copy.js react-17 @esm-bundle/react esm/react.production.min.*",
     "eik:login": "eik login",
     "eik:publish": "eik publish",
     "eik:alias": "eik npm-alias",
     "eik:publish:ci": "../../scripts/publish.js react-17 @esm-bundle/react stripPrerelease"
   },
-  "author": "",
-  "license": "ISC",
   "dependencies": {
     "@esm-bundle/react": "17.0.2-fix.1"
   },

--- a/packages/react-18/.npmrc
+++ b/packages/react-18/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/react-18/package.json
+++ b/packages/react-18/package.json
@@ -4,6 +4,7 @@
   "description": "An ESM version of React for Finn",
   "type": "module",
   "scripts": {
+    "copy": "echo 'noop';",
     "build": "npx rollup -c",
     "eik:login": "eik login",
     "eik:publish": "eik publish",

--- a/packages/react-18/package.json
+++ b/packages/react-18/package.json
@@ -1,21 +1,16 @@
 {
-  "name": "react",
-  "private": "true",
+  "name": "@finn-no/react",
   "version": "0.0.0",
   "description": "An ESM version of React for Finn",
   "type": "module",
-  "main": "react.production.min.js",
   "scripts": {
     "build": "npx rollup -c",
-    "copy": "echo \"No copy command installed\"",
     "eik:login": "eik login",
     "eik:publish": "eik publish",
     "eik:alias": "eik npm-alias",
     "eik:publish:ci": "../../scripts/publish.js react-18 react",
     "postinstall": "npm run build"
   },
-  "author": "",
-  "license": "ISC",
   "dependencies": {
     "react": "18.2.0"
   },
@@ -28,6 +23,7 @@
     "rollup": "3.3.0"
   },
   "eik": {
+    "name": "react",
     "server": "https://assets.finn.no",
     "type": "npm",
     "files": "dist"

--- a/packages/react-18/rollup.config.js
+++ b/packages/react-18/rollup.config.js
@@ -1,7 +1,20 @@
+import { createRequire } from "node:module";
+import { join, dirname, basename } from "node:path";
+import { readFileSync, writeFileSync } from "node:fs";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import terser from "@rollup/plugin-terser";
 import commonjs from "@rollup/plugin-commonjs";
 import replace from "@rollup/plugin-replace";
+
+const { resolve } = createRequire(import.meta.url);
+
+// patch react exports to give access to files in cjs directory that we need for our build.
+const reactPath = resolve('react');
+const reactPackageJSONPath = join(dirname(reactPath), 'package.json');
+const reactPackageJSON = JSON.parse(readFileSync(reactPackageJSONPath, { encoding: 'utf8' }));
+reactPackageJSON.exports["./cjs/react.development.js"] = "./cjs/react.development.js";
+reactPackageJSON.exports["./cjs/react.production.min.js"] = "./cjs/react.production.min.js";
+writeFileSync(reactPackageJSONPath, JSON.stringify(reactPackageJSON, null, 2));
 
 export default [
   {

--- a/packages/react-dom-17/package.json
+++ b/packages/react-dom-17/package.json
@@ -4,6 +4,7 @@
   "description": "An ESM version of React Dom for Finn",
   "type": "module",
   "scripts": {
+    "copy": "echo 'noop';",
     "build": "npx rollup -c",
     "eik:login": "eik login",
     "eik:publish": "eik publish",

--- a/packages/react-dom-17/package.json
+++ b/packages/react-dom-17/package.json
@@ -1,21 +1,16 @@
 {
-  "name": "react-dom-17",
-  "private": "true",
+  "name": "@finn-no/react-dom-17",
   "version": "0.0.0",
   "description": "An ESM version of React Dom for Finn",
   "type": "module",
   "scripts": {
     "build": "npx rollup -c",
-    "copy": "echo \"No copy command installed\"",
     "eik:login": "eik login",
     "eik:publish": "eik publish",
     "eik:alias": "eik npm-alias",
     "postinstall": "npm run build",
     "eik:publish:ci": "../../scripts/publish.js react-dom-17 @esm-bundle/react-dom stripPrerelease"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
   "dependencies": {
     "@esm-bundle/react-dom": "17.0.2-fix.0"
   },

--- a/packages/react-dom-18/.npmrc
+++ b/packages/react-dom-18/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/react-dom-18/package.json
+++ b/packages/react-dom-18/package.json
@@ -1,6 +1,5 @@
 {
-  "name": "react-dom",
-  "private": "true",
+  "name": "@finn-no/react-dom",
   "version": "0.0.0",
   "description": "An ESM version of React Dom for Finn",
   "type": "module",
@@ -8,16 +7,12 @@
     "build:dev": "NODE_ENV=development npx rollup -c",
     "build:prod": "NODE_ENV=production npx rollup -c",
     "build": "npm run build:dev && npm run build:prod",
-    "copy": "echo \"No copy command installed\"",
     "eik:login": "eik login",
     "eik:publish": "eik publish",
     "eik:alias": "eik npm-alias",
     "postinstall": "npm run build",
     "eik:publish:ci": "../../scripts/publish.js react-dom-18 react-dom"
   },
-  "keywords": [],
-  "author": "",
-  "license": "ISC",
   "dependencies": {
     "react-dom": "18.2.0"
   },
@@ -31,6 +26,7 @@
     "semver": "7.3.8"
   },
   "eik": {
+    "name": "react-dom",
     "server": "https://assets.finn.no",
     "type": "npm",
     "files": "dist"

--- a/packages/react-dom-18/package.json
+++ b/packages/react-dom-18/package.json
@@ -4,6 +4,7 @@
   "description": "An ESM version of React Dom for Finn",
   "type": "module",
   "scripts": {
+    "copy": "echo 'noop';",
     "build:dev": "NODE_ENV=development npx rollup -c",
     "build:prod": "NODE_ENV=production npx rollup -c",
     "build": "npm run build:dev && npm run build:prod",

--- a/packages/react-dom-18/rollup.config.js
+++ b/packages/react-dom-18/rollup.config.js
@@ -11,7 +11,7 @@ const env = process.env.NODE_ENV;
 const reactPkg = new URL("../react-18/package.json", import.meta.url);
 const reactDomPkg = new URL("./package.json", import.meta.url);
 
-const { name } = JSON.parse(fs.readFileSync(reactPkg.pathname, "utf8"));
+const { eik: { name } } = JSON.parse(fs.readFileSync(reactPkg.pathname, "utf8"));
 const {
   dependencies: { "react-dom": version },
 } = JSON.parse(fs.readFileSync(reactDomPkg.pathname, "utf8"));

--- a/packages/trackjs/package.json
+++ b/packages/trackjs/package.json
@@ -6,6 +6,7 @@
     "type": "module",
     "scripts": {
         "copy": "../../scripts/copy.js trackjs trackjs index.esm.js",
+        "build": "echo 'noop';",
         "eik:login": "eik login",
         "eik:publish": "eik publish",
         "eik:alias": "eik npm-alias",

--- a/packages/trackjs/package.json
+++ b/packages/trackjs/package.json
@@ -1,24 +1,21 @@
 {
-    "name": "trackjs",
+    "name": "@finn-no/trackjs",
     "private": "true",
     "version": "0.0.0",
     "description": "An ESM version of TrackJS for Finn",
     "type": "module",
-    "main": "trackjs.production.min.js",
     "scripts": {
-        "build": "echo \"No build command installed\"",
         "copy": "../../scripts/copy.js trackjs trackjs index.esm.js",
         "eik:login": "eik login",
         "eik:publish": "eik publish",
         "eik:alias": "eik npm-alias",
         "eik:publish:ci": "../../scripts/publish.js trackjs trackjs"
     },
-    "author": "",
-    "license": "ISC",
     "dependencies": {
         "trackjs": "3.10.1"
     },
     "eik": {
+        "name": "trackjs",
         "server": "https://assets.finn.no",
         "type": "npm",
         "files": {

--- a/packages/vue/.npmrc
+++ b/packages/vue/.npmrc
@@ -1,1 +1,0 @@
-package-lock=false

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -1,9 +1,8 @@
 {
-  "name": "vue-lib",
+  "name": "@finn-no/vue",
   "version": "0.0.0",
-  "private": "true",
   "description": "An ESM version of Vue for Finn",
-  "main": "index.js",
+  "type": "module",
   "scripts": {
     "copy": "../../scripts/copy.js vue vue dist/*.js",
     "eik:login": "eik login",
@@ -11,26 +10,13 @@
     "eik:alias": "eik npm-alias",
     "eik:publish:ci": "../../scripts/publish.js vue vue"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/finn-no/eik-shared-libs.git"
+  "dependencies": {
+    "vue": "3.2.41"
   },
-  "author": "",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/finn-no/eik-shared-libs/issues"
-  },
-  "homepage": "https://github.com/finn-no/eik-shared-libs#readme",
   "eik": {
     "name": "vue",
     "server": "https://assets.finn.no",
     "type": "npm",
     "files": "dist"
-  },
-  "dependencies": {
-    "vue": "3.2.41"
-  },
-  "devDependencies": {
-    "esbuild": "0.15.12"
   }
 }

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -5,6 +5,7 @@
   "type": "module",
   "scripts": {
     "copy": "../../scripts/copy.js vue vue dist/*.js",
+    "build": "echo 'noop';",
     "eik:login": "eik login",
     "eik:publish": "eik publish",
     "eik:alias": "eik npm-alias",

--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "dependencyDashboard": true,
   "packageRules": [
     {
-      "depTypeList": ["dependencies"],
+      "matchDepTypes": ["dependencies"],
       "schedule": [
         "after 6pm every weekday",
         "before 6am every weekday"
@@ -16,25 +16,13 @@
       }
     },
     {
-      "depTypeList": ["devDependencies"],
+      "matchDepTypes": ["devDependencies"],
       "schedule": ["every weekend"],
       "rangeStrategy": "pin",
       "automerge": true,
       "major": {
         "automerge": false
       }
-    },
-    {
-      "groupName": "All dependencies (non-major)",
-      "matchDepTypes": ["dependencies"],
-      "matchUpdateTypes": ["patch", "minor"]
-    },
-    {
-      "groupName": "Build packages",
-      "matchDepTypes": ["devDependencies"],
-      "matchPackagePatterns": [
-        "esbuild"
-      ]
     }
   ]
 }

--- a/scripts/copy.js
+++ b/scripts/copy.js
@@ -23,7 +23,7 @@ const cwd = join(dirname, '../packages', packageNameArg);
 // find closest node_modules folder. This might be in the package folder or at the monorepo root.
 const nodeModulesPath = findup(`node_modules`, { cwd }); 
 // build the dependency path from the closest node_modules folder
-const dependencyPath = join(nodeModulesPath, dependencyNameArg);
+const dependencyPath = join(nodeModulesPath || '', dependencyNameArg);
 
 // make directory if it doesn't already exist
 execSync(`mkdir -p ${join(cwd, 'dist')}`);

--- a/scripts/publish.js
+++ b/scripts/publish.js
@@ -19,7 +19,7 @@ const packageJSONPath = join(cwd, './package.json');
 const packageJSON = JSON.parse(readFileSync(packageJSONPath, 'utf8'));
 
 // grab Eik variables from package.json
-const { eik: { name: eikName, server, files, type }, name: pkgName } = packageJSON;
+const { eik: { name, server, files, type } } = packageJSON;
 
 // grab version directly from the dependency
 let version = packageJSON.dependencies[dependencyNameArg];
@@ -27,9 +27,6 @@ let version = packageJSON.dependencies[dependencyNameArg];
 if (stripPrerelease) {
     version = `${semver.major(version)}.${semver.minor(version)}.${semver.patch(version)}`;
 }
-
-// allow eik name field to overwrite package name field
-const name = eikName || pkgName;
 
 const token = await eik.login({
     server,


### PR DESCRIPTION
After a bit of trying and erroring it seems like Renovate bot is not bumping a dependency when the package.json is like so:

```json
{
  "name": "vue",
  "dependencies": {
    "vue": "3.2.41"
  }
}
```

Which make sense because this is a module depending on itself which, from the perspective of a dependency update bot, opens quite a rabbit hole. 

This is why ex the React 17 package, which had different name (`react-17`) than the dependency, was updated and not ex Vue.

What we have to do is to name the package something else than the dependency and then define the name it should be published with to Eik. Something like this:

```json
{
  "name": "@finn-no/vue",
  "dependencies": {
    "vue": "3.2.41"
  },
  "eik": {
    "name": "vue",
  }
}
```

This should make Renovate bot process things correctly and give us PRs on all versions. 