### PR TITLE
ci: Make separate Renovate bot PRs for Vue 2 and 3

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,16 @@
       "major": {
         "automerge": false
       }
+    },
+    {
+      "matchPackageNames": ["vue"],
+      "matchCurrentVersion": "2",
+      "allowedVersions": "2"
+    },
+    {
+      "matchPackageNames": ["vue"],
+      "matchCurrentVersion": "3",
+      "allowedVersions": "3"
     }
   ]
 }


### PR DESCRIPTION
There are one package for Vue version 2 and one package for Vue version 3 in this repo. With the current Renovate bot config the bot will try to update the Vue version 2 package to version 3 for each run. I doubt that is what we want and I assume we want to publish version 2 releases in parallel with version 3 releases to Eik as both versions can still get releases.

This PR configures Renovate to create PRs for Vue version 2 with only updates in the version 2 range and PRs for Vue version 3 with only updates in the version 3 range. 

Tested here: 
Version 2 range PR: https://github.com/trygve-lie/renovate-test/pull/7
Version 3 range PR: https://github.com/trygve-lie/renovate-test/pull/8