### PR TITLE
feat: add lit labs ssr client package

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "type": "module",
   "license": "MIT",
   "scripts": {
-    "build": "npm run build -ws",
-    "copy": "npm run copy -ws",
-    "publish": "npm run eik:publish:ci -ws"
+    "build": "npm run build --workspaces --if-present",
+    "copy": "npm run copy --workspaces --if-present",
+    "publish": "npm run eik:publish:ci --workspaces --if-present"
   },
   "workspaces": [
     "packages/react-17",
@@ -20,7 +20,8 @@
     "packages/lit",
     "packages/lit-element",
     "packages/lit-html",
-    "packages/podium-browser"
+    "packages/podium-browser",
+    "packages/lit-labs-ssr-client"
   ],
   "devDependencies": {
     "@eik/cli": "2.0.22",

--- a/packages/lit-labs-ssr-client/esbuild.js
+++ b/packages/lit-labs-ssr-client/esbuild.js
@@ -1,0 +1,25 @@
+import { createRequire } from "module";
+import esbuild from "esbuild";
+
+const { resolve } = createRequire(import.meta.url);
+
+await Promise.all([
+	esbuild.build({
+		entryPoints: [resolve("@lit-labs/ssr-client/lit-element-hydrate-support.js")],
+		bundle: true,
+		minify: true,
+		format: "esm",
+		outfile: "./dist/lit-element-hydrate-support.js",
+		target: ["es2017"],
+		sourcemap: true,
+	}),
+	esbuild.build({
+		entryPoints: [resolve("@lit-labs/ssr-client/directives/render-light.js")],
+		bundle: true,
+		minify: true,
+		format: "esm",
+		outfile: "./dist/directives/render-light.js",
+		target: ["es2017"],
+		sourcemap: true,
+	})
+]);

--- a/packages/lit-labs-ssr-client/package.json
+++ b/packages/lit-labs-ssr-client/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@borealis/lit-ssr-client",
+  "version": "0.0.0",
+  "description": "An ESM version of @lit-labs/ssr-client for NMP",
+  "type": "module",
+  "scripts": {
+    "copy": "echo 'noop';",
+    "build": "node ./esbuild.js",
+    "eik:login": "eik login",
+    "eik:publish": "eik publish",
+    "eik:alias": "eik npm-alias",
+    "eik:publish:ci": "../../scripts/publish.js lit-labs-ssr-client @lit-labs/ssr-client"
+  },
+  "dependencies": {
+    "@lit-labs/ssr-client": "1.1.5"
+  },
+  "devDependencies": {
+    "esbuild": "0.19.0"
+  },
+  "eik": {
+    "name": "@lit-labs/ssr-client",
+    "server": "https://assets.finn.no",
+    "type": "npm",
+    "files": "dist"
+  }
+}


### PR DESCRIPTION
Adds a global shared, minified and bundled version of @lit-labs/ssr-client so that we can reference it directly in HTML template