### PR TITLE
fix: improve lit static bundle size

### DIFF
--- a/packages/lit-2/esbuild.js
+++ b/packages/lit-2/esbuild.js
@@ -1,4 +1,7 @@
 import esbuild from "esbuild";
+import { plugin, load } from "@eik/esbuild-plugin";
+
+await load({ maps: [{ imports: { "./lit-html.js": "./lit.min.js" } }] });
 
 await esbuild.build({
   entryPoints: ["./lit.min.js", "static-html.js"],
@@ -8,4 +11,5 @@ await esbuild.build({
   outdir: "dist/",
   target: ["es2017"],
   sourcemap: true,
+  plugins: [plugin()],
 });

--- a/packages/lit-2/package.json
+++ b/packages/lit-2/package.json
@@ -15,7 +15,8 @@
     "lit": "2.8.0"
   },
   "devDependencies": {
-    "esbuild": "0.19.11"
+    "esbuild": "0.19.11",
+    "@eik/esbuild-plugin": "1.1.45"
   },
   "eik": {
     "name": "lit-2",

--- a/packages/lit-3/esbuild.js
+++ b/packages/lit-3/esbuild.js
@@ -1,4 +1,7 @@
 import esbuild from "esbuild";
+import { plugin, load } from "@eik/esbuild-plugin";
+
+await load({ maps: [{ imports: { "./lit-html.js": "./lit.min.js" } }] });
 
 await esbuild.build({
   entryPoints: ["./lit.min.js", "static-html.js"],
@@ -8,4 +11,5 @@ await esbuild.build({
   outdir: "dist/",
   target: ["es2017"],
   sourcemap: true,
+  plugins: [plugin()],
 });

--- a/packages/lit-3/package.json
+++ b/packages/lit-3/package.json
@@ -15,7 +15,8 @@
     "lit": "3.1.0"
   },
   "devDependencies": {
-    "esbuild": "0.19.11"
+    "esbuild": "0.19.11",
+    "@eik/esbuild-plugin": "1.1.45"
   },
   "eik": {
     "name": "lit-3",


### PR DESCRIPTION
After discussion here https://github.com/lit/lit/issues/4459 I've had a crack at improving things re: the Lit static bundle.

This PR reduces the bundle size of the Lit static bundle from 8kb to 1kb at the cost of an extra request. 
However, since the mapping is to the main lit bundle, in most cases the user will already have this file in browser cache and won't pay the hit. (Also since the main lit bundle is typically preloaded). 

