### PR TITLE
fix: point to `lit-2` and `lit-3` packages in Warp Elements

### DIFF
--- a/packages/warp-ds-elements-core/rollup.config.js
+++ b/packages/warp-ds-elements-core/rollup.config.js
@@ -1,15 +1,15 @@
 import { createRequire } from "module";
 import plugin from "@eik/rollup-plugin";
-import terser from '@rollup/plugin-terser';
-import { nodeResolve } from '@rollup/plugin-node-resolve';
-import commonjs from '@rollup/plugin-commonjs';
+import terser from "@rollup/plugin-terser";
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
 
 const { resolve } = createRequire(import.meta.url);
 
-const versions = ["v2", "v3"];
+const versions = ["2", "3"];
 const config = [];
 
-const lit = (version) => `https://assets.finn.no/npm/lit/${version}/lit.min.js`;
+const lit = (version) => `https://assets.finn.no/npm/lit-${version}/v${version}/lit.min.js`;
 
 for (const version of versions) {
   config.push({
@@ -21,7 +21,7 @@ for (const version of versions) {
       terser(),
     ],
     output: {
-      file: `dist/lit-${version}.js`,
+      file: `dist/lit-v${version}.js`,
       format: "esm",
     },
   });
@@ -34,7 +34,7 @@ for (const version of versions) {
       terser(),
     ],
     output: {
-      file: `dist/global/lit-${version}.js`,
+      file: `dist/global/lit-v${version}.js`,
       format: "esm",
     },
   });

--- a/packages/warp-ds-elements/rollup.config.js
+++ b/packages/warp-ds-elements/rollup.config.js
@@ -1,15 +1,15 @@
 import { createRequire } from "module";
 import plugin from "@eik/rollup-plugin";
-import terser from '@rollup/plugin-terser';
-import { nodeResolve } from '@rollup/plugin-node-resolve';
-import commonjs from '@rollup/plugin-commonjs';
+import terser from "@rollup/plugin-terser";
+import { nodeResolve } from "@rollup/plugin-node-resolve";
+import commonjs from "@rollup/plugin-commonjs";
 
 const { resolve } = createRequire(import.meta.url);
 
-const versions = ["v2", "v3"];
+const versions = ["2", "3"];
 const config = [];
 
-const lit = (version) => `https://assets.finn.no/npm/lit/${version}/lit.min.js`;
+const lit = (version) => `https://assets.finn.no/npm/lit-${version}/v${version}/lit.min.js`;
 
 for (const version of versions) {
   config.push({
@@ -21,7 +21,7 @@ for (const version of versions) {
       terser(),
     ],
     output: {
-      file: `dist/lit-${version}.js`,
+      file: `dist/lit-v${version}.js`,
       format: "esm",
     },
   });


### PR DESCRIPTION
We end up with double downloads of Lit since the Warp packages point to a different asset than the import map.

Related to:

- #146 
- #149 
- #160 


![](https://github.com/finn-no/eik-shared-libs/assets/1223410/56354162-d685-4441-b37c-2a354f1f9208)
![](https://github.com/finn-no/eik-shared-libs/assets/1223410/11f47d81-4b26-44d4-996a-98c112147637)

