### PR TITLE
fix: use same folder name as current asset

### DIFF
--- a/packages/warp-ds-elements/package.json
+++ b/packages/warp-ds-elements/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "copy": "echo 'noop';",
-    "build": "npx rollup -c",
+    "build": "npx rollup -c && mv dist/components dist/packages && mv dist/lit-3/components dist/lit-3/packages",
     "eik:login": "eik login",
     "eik:publish": "eik publish",
     "eik:alias": "eik npm-alias",

--- a/packages/warp-ds-elements/package.json
+++ b/packages/warp-ds-elements/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "copy": "echo 'noop';",
-    "build": "npx rollup -c && mv dist/components dist/packages && mv dist/lit-3/components dist/lit-3/packages",
+    "build": "rm -rf dist && npx rollup -c && mv dist/components dist/packages && mv dist/lit-3/components dist/lit-3/packages && mv dist/toast/index.js dist/api.js",
     "eik:login": "eik login",
     "eik:publish": "eik publish",
     "eik:alias": "eik npm-alias",

--- a/packages/warp-ds-elements/rollup.config.js
+++ b/packages/warp-ds-elements/rollup.config.js
@@ -76,7 +76,22 @@ for (const litVersion of litVersions) {
     config.push({
       input: import.meta.resolve(`${moduleName}${subpathImportPart}`).replace("file:/", ""),
       plugins: [
-        plugin({ maps: [{ imports: { lit: lit(litVersion) } }] }),
+        plugin({
+          maps: [
+            {
+              imports: {
+                "@warp-ds/elements-core":
+                  "https://assets.finn.no/pkg/@warp-ds/elements-core/v0/element.js",
+                "@warp-ds/elements-core/element.js":
+                  "https://assets.finn.no/pkg/@warp-ds/elements-core/v0/element.js",
+                "@warp-ds/elements-core/global.js":
+                  "https://assets.finn.no/pkg/@warp-ds/elements-core/v0/global.js",
+                lit: lit(litVersion),
+                "lit-html": `https://assets.finn.no/npm/lit-html/v${litVersion}/lit-html.min.js`,
+              },
+            },
+          ],
+        }),
         nodeResolve(),
         commonjs(),
         terser(),


### PR DESCRIPTION
The folder name on Eik today doesn't match the one in `package.json`'s `exports` field.