### PR TITLE
feat: add braze web sdk

### DIFF
--- a/packages/braze/esbuild.js
+++ b/packages/braze/esbuild.js
@@ -1,0 +1,14 @@
+import { createRequire } from "module";
+import esbuild from "esbuild";
+
+const { resolve } = createRequire(import.meta.url);
+
+await esbuild.build({
+  entryPoints: [resolve("@braze/web-sdk")],
+  bundle: true,
+  minify: true,
+  format: "esm",
+  outfile: "./dist/index.js",
+  target: ["es2017"],
+  sourcemap: true,
+});

--- a/packages/braze/package.json
+++ b/packages/braze/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "braze-web-sdk",
+  "version": "0.0.0",
+  "description": "Braze global script for NMP",
+  "type": "module",
+  "scripts": {
+    "copy": "echo 'noop';",
+    "build": "node ./esbuild.js",
+    "eik:login": "eik login",
+    "eik:publish": "eik publish",
+    "eik:alias": "eik npm-alias",
+    "eik:publish:ci": "../../scripts/publish.js braze @braze/web-sdk"
+  },
+  "dependencies": {
+    "@braze/web-sdk": "5.2.0"
+  },
+  "eik": {
+    "name": "@braze/web-sdk",
+    "server": "https://assets.finn.no",
+    "type": "npm",
+    "files": "dist"
+  }
+}


### PR DESCRIPTION
The Braze web SDK is pretty huge so it be best if we got it on Eik.
See: https://github.schibsted.io/nmp-web/braze-integration-script/pull/1