### PR TITLE
Build and copy fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "@eik/cli": "3.1.3",
     "browserslist": "4.23.3",
     "browserslist-to-esbuild": "2.1.1",
-    "findup-sync": "5.0.0",
     "semver": "7.6.3"
   }
 }

--- a/packages/lit-labs-ssr-client/esbuild.js
+++ b/packages/lit-labs-ssr-client/esbuild.js
@@ -1,15 +1,19 @@
+import { join, dirname } from "node:path";
 import { createRequire } from "module";
 import { build } from "../../esbuild.js";
 
 const { resolve } = createRequire(import.meta.url);
 
+const renderLightDirectivePath = resolve("@lit-labs/ssr-client/directives/render-light.js");
+const litElementHydrateSupportPath = join(dirname(renderLightDirectivePath), '..', 'lit-element-hydrate-support.js');
+
 await Promise.all([
   build({
-    entryPoints: [resolve("@lit-labs/ssr-client/lit-element-hydrate-support.js")],
+    entryPoints: [litElementHydrateSupportPath],
     outfile: "./dist/lit-element-hydrate-support.js",
   }),
   build({
-    entryPoints: [resolve("@lit-labs/ssr-client/directives/render-light.js")],
+    entryPoints: [renderLightDirectivePath],
     outfile: "./dist/directives/render-light.js",
   }),
 ]);


### PR DESCRIPTION
I still don't fully understand many things about this. Like, why was it working at all? And why did it break now? And why did NPM suddenly start moving packages to the root when it wasn't before?

In any case, this PR:
1. makes copying more robust by falling back to looking in the root node_modules folder if a copy operation fails
2. for @lit-labs/ssr-client, bypasses the node resolve algorithm because it was loading the node version when we wanted the browser version (I've seen this before and there's no way to force the resolve algorithm to act as a browser environment as far as Im aware)
3. renames files to .cjs to force Esbuild to treat them as such. Presumably the previous solution of using an Esbuild flag worked but it doesn't anymore for whatever reason. 

A lot of head scratchers in there but things are working again.