### PR TITLE
fix(react): add missing named exports

### DIFF
--- a/packages/react/development.js
+++ b/packages/react/development.js
@@ -3,6 +3,7 @@ import React from "react/cjs/react.development.js";
 export default React;
 export const __esmModule = true;
 export const {
+  Activity,
   Fragment,
   StrictMode,
   Profiler,

--- a/packages/react/development.js
+++ b/packages/react/development.js
@@ -14,6 +14,7 @@ export const {
   __CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE,
   act,
   cache,
+  cacheSignal,
   cloneElement,
   createContext,
   createElement,

--- a/packages/react/development.js
+++ b/packages/react/development.js
@@ -15,6 +15,7 @@ export const {
   act,
   cache,
   cacheSignal,
+  captureOwnerStack,
   cloneElement,
   createContext,
   createElement,

--- a/packages/react/development.js
+++ b/packages/react/development.js
@@ -31,6 +31,7 @@ export const {
   useDebugValue,
   useDeferredValue,
   useEffect,
+  useEffectEvent,
   useId,
   useImperativeHandle,
   useInsertionEffect,

--- a/packages/react/production.js
+++ b/packages/react/production.js
@@ -14,6 +14,7 @@ export const {
   __CLIENT_INTERNALS_DO_NOT_USE_OR_WARN_USERS_THEY_CANNOT_UPGRADE,
   act,
   cache,
+  cacheSignal,
   cloneElement,
   createContext,
   createElement,

--- a/packages/react/production.js
+++ b/packages/react/production.js
@@ -15,6 +15,7 @@ export const {
   act,
   cache,
   cacheSignal,
+  captureOwnerStack,
   cloneElement,
   createContext,
   createElement,

--- a/packages/react/production.js
+++ b/packages/react/production.js
@@ -3,6 +3,7 @@ import React from "react/cjs/react.production.js";
 export default React;
 export const __esmModule = true;
 export const {
+  Activity,
   Fragment,
   StrictMode,
   Profiler,

--- a/packages/react/production.js
+++ b/packages/react/production.js
@@ -31,6 +31,7 @@ export const {
   useDebugValue,
   useDeferredValue,
   useEffect,
+  useEffectEvent,
   useId,
   useImperativeHandle,
   useInsertionEffect,


### PR DESCRIPTION
Adds some missing named exports to React:
- `Activity`
- `cacheSignal`
- `captureOwnerStack`
- `useEffectEvent`